### PR TITLE
fix(ITextSearchableColumn): make SelectValue not internal

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
@@ -2,7 +2,7 @@
 {
     public interface ITextSearchableColumn<TModel>
     {
-        public bool IsTextSearchEnabled { get; }
-        internal string? SelectValue(TModel model);
+        bool IsTextSearchEnabled { get; }
+        string? SelectValue(TModel model);
     }
 }


### PR DESCRIPTION
Ported from https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/pull/367 by [@IvanJosipovic](https://github.com/IvanJosipovic)

> Attempting to make a custom column with the ITextSearchableColumn inteface is not possible due to SelectValue being internal.

> <img width="1642" height="909" alt="image" src="https://github.com/user-attachments/assets/3457c280-f9bc-4ac8-a9dd-0a27a07dc1ad" />
