### PR TITLE
Fix: Text column value clears on commit without changes

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -93,8 +93,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             if (!_isEditing && !IsReadOnly)
             {
-                _isEditing = true;
                 _editText = Text;
+                _isEditing = true;
             }
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
@@ -94,6 +94,19 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
             Assert.Equal(new[] { "initial" }, result);
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Unchanged_Value_Clears_On_CommitEdit_Without_Changes()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, binding, false);
+
+            target.BeginEdit();
+            target.EndEdit();
+
+            Assert.Equal("initial", target.Text);
+            Assert.Equal("initial", target.Value);
+        }
+
         public class StringFormat
         {
             public StringFormat()


### PR DESCRIPTION
Closes https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/326