### PR TITLE
improve aot and trimming compatiblitiy for themes

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml.cs
@@ -1,0 +1,8 @@
+﻿using Avalonia.Styling;
+
+namespace Avalonia.Controls.Themes
+{
+    public class Fluent : Styles
+    {
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml.cs
@@ -1,6 +1,6 @@
 ﻿using Avalonia.Styling;
 
-namespace Avalonia.Controls.Themes
+namespace Avalonia.Controls.TreeDataGrid.Themes
 {
     public class Fluent : Styles
     {

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml
@@ -1,0 +1,6 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <StyleInclude Source="/Themes/Generic.axaml" />
+
+</Styles>

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml.cs
@@ -1,0 +1,8 @@
+﻿using Avalonia.Styling;
+
+namespace Avalonia.Controls.Themes
+{
+    public class Simple : Styles
+    {
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Simple.axaml.cs
@@ -1,6 +1,6 @@
 ﻿using Avalonia.Styling;
 
-namespace Avalonia.Controls.Themes
+namespace Avalonia.Controls.TreeDataGrid.Themes
 {
     public class Simple : Styles
     {


### PR DESCRIPTION
With this change it is possible to reference the theme directly from code, rather than relying on the URL.
This remove the needs to have special trim instructions to preserve the style during trimming.